### PR TITLE
TASK-32436: make total count in ODataQuery optional

### DIFF
--- a/example/odata.go
+++ b/example/odata.go
@@ -35,7 +35,7 @@ func example() {
 	var object []interface{}
 	collection := mainSession.Database("testdb").Collection("collectionName")
 
-	if _, err := odata.ODataQuery(nil, testURL.Query(), &object, collection); err != nil {
+	if _, err := odata.ODataQuery(nil, testURL.Query(), &object, collection, false); err != nil {
 		fmt.Errorf("Error: %s", err.Error())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -35,7 +35,7 @@ func TestODataQuery(t *testing.T) {
 	var object []interface{}
 	collection := mainSession.Database("test").Collection("tests")
 
-	if _, err := ODataQuery(nil, testURL.Query(), &object, collection); err != nil {
+	if _, err := ODataQuery(nil, testURL.Query(), &object, collection, false); err != nil {
 		t.Errorf("Error: %s", err.Error())
 	}
 }
@@ -54,7 +54,7 @@ func TestODataFilter(t *testing.T) {
 	var object []interface{}
 	collection := mainSession.Database("test").Collection("tests")
 
-	if _, err := ODataQuery(nil, testURL.Query(), &object, collection); err != nil {
+	if _, err := ODataQuery(nil, testURL.Query(), &object, collection, false); err != nil {
 		t.Errorf("Error: %s", err.Error())
 	}
 }
@@ -74,7 +74,7 @@ func TestODataFunctions(t *testing.T) {
 	var object []interface{}
 	collection := mainSession.Database("test").Collection("tests")
 
-	if _, err := ODataQuery(nil, testURL.Query(), &object, collection); err != nil {
+	if _, err := ODataQuery(nil, testURL.Query(), &object, collection, false); err != nil {
 		t.Errorf("Error: %s", err.Error())
 	}
 
@@ -95,7 +95,7 @@ func TestODataFilterGreaterLessThan(t *testing.T) {
 	var object []interface{}
 	collection := mainSession.Database("test").Collection("tests")
 
-	if _, err := ODataQuery(nil, testURL.Query(), &object, collection); err != nil {
+	if _, err := ODataQuery(nil, testURL.Query(), &object, collection, false); err != nil {
 		t.Errorf("Error: %s", err.Error())
 	}
 }
@@ -138,7 +138,7 @@ func TestODataWithFilter(t *testing.T) {
 			return
 		}
 
-		_, queryErr := ODataQuery(nil, testURL.Query(), &object, collection)
+		_, queryErr := ODataQuery(nil, testURL.Query(), &object, collection, false)
 
 		// an error happened, is it expected?
 		if (queryErr != nil) != (expectedVal.Err != nil) {


### PR DESCRIPTION
If caller didn't ask for the total count of documents, don't waste cpu/time asking Mongo, just return 0 instead